### PR TITLE
Simple change to bring chat window to bottom when rolling stress and fallout

### DIFF
--- a/release-notes/v0.4.9/lang/en.json
+++ b/release-notes/v0.4.9/lang/en.json
@@ -1,0 +1,14 @@
+{
+    "versions": {
+        "0_4_9": {
+            "version": "v0.4.9",
+            "changes":[
+                "Another update from stuttste",
+                "Simple change to bring chat window to bottom when rolling stress and fallout"
+            ],
+            "notes":[
+                "Added setFalloutRoll so the Message would behave more like the stress roll as I was finding it hard to guarantee message was updated before calling scrollToBottom"
+            ]
+        }
+    }
+}

--- a/src/chat-messages/index.js
+++ b/src/chat-messages/index.js
@@ -77,6 +77,11 @@ class HeartChatMessage extends ChatMessage {
         return
     }
 
+    async setFalloutRoll(roll) {
+        const json = roll.toJSON()
+        await this.setFlag('heart', 'fallout-roll', json);
+    }
+
     get showFalloutRollButton() {
         const showFalloutRollButton = this.getFlag('heart', 'show-fallout-roll-button')
         if (this.falloutRoll !== undefined) {

--- a/src/rolls/heart-roll/roll.js
+++ b/src/rolls/heart-roll/roll.js
@@ -256,6 +256,9 @@ export default class HeartRoll extends Roll {
 
             await msg.setStressRoll(stressRoll);
             msg.showStressRollButton = false;
+
+            await ui.chat.updateMessage(msg, true);
+            ui.chat.scrollBottom();
         });
     }
 }

--- a/src/rolls/stress-roll/roll.js
+++ b/src/rolls/stress-roll/roll.js
@@ -180,8 +180,11 @@ export default class StressRoll extends Roll {
 
             await falloutRoll.evaluate({async: true});
             
-            msg.falloutRoll = falloutRoll;
+            await msg.setFalloutRoll(falloutRoll);
             msg.showFalloutRollButton = false;
+
+            await ui.chat.updateMessage(msg, true);
+            ui.chat.scrollBottom();
         });
     }
 }

--- a/src/rolls/stress-roll/roll.js
+++ b/src/rolls/stress-roll/roll.js
@@ -165,6 +165,9 @@ export default class StressRoll extends Roll {
             await stressRoll.takeStress(actor_id)
             msg.showTakeStressButton = false;
             msg.showFalloutRollButton = true;
+            
+            await ui.chat.updateMessage(msg, true);
+            ui.chat.scrollBottom();
         });
 
         html.on('click', '.stress-roll [data-action=roll-fallout]', async function(ev) {


### PR DESCRIPTION
Added ui.chat.scrollToBottom in a couple places to bring the chat window down after new results are posted from rolls.

Added setFalloutRoll so the Message would behave more like the stress roll as I was finding it hard to guarantee message was updated before calling scrollToBottom